### PR TITLE
Fix oh-my-zsh installation. Add zsh steps to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,50 @@
 
 ## Installation
 
+### Dotfiles
+
 ```
 $ git clone https://github.com/doriath/dotfiles.git ~/.dotfiles
 $ cd ~/.dotfiles
 $ ./install
 ```
+
+### ZSH
+
+#### OS X
+
+Install zsh and zsh completions using homebrew for most up to date zsh.
+
+```
+brew install zsh zsh-completions
+```
+
+Make zsh your default shell.
+
+```
+sudo dscl . -create /Users/$USER UserShell /usr/local/bin/zsh
+```
+
+Or just use OS X included zsh.
+
+```
+chch -s /bin/zsh
+```
+
+#### Linux
+
+Install zsh.
+
+```
+sudo apt-get install zsh
+```
+
+Make zsh your default shell.
+
+```
+chsh -s /bin/zsh
+```
+
 
 Note that the install script is idempotent: it can safely be run multiple
 times.

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -9,4 +9,4 @@
       force: true
 - shell:
   - [git submodule update --init --recursive, Installing submodules]
-  - ['sh -c "$(wget https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"', Installing oh-my-zsh]
+  - ['git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh', Installing oh-my-zsh]


### PR DESCRIPTION
Your oh-my-zsh installation process would backup newly linked .zshrc file and replaced it with default one. Also, it would not prompt you for password needed for shell change to zsh so I added instructions for that in README file. Your old procedure would not work with a system without 'wget' but it would still finish "successfully".